### PR TITLE
Remove duplicate declaration of gutterSize variable

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -202,7 +202,7 @@ function Split({
       let gutterSize = 0
       if (children.length > 1) {
         const gutter = gutters[isLast ? idx-1 : idx];
-        let gutterSize = gutter.getBoundingClientRect()[direction === SplitDirection.Horizontal ? 'width' : 'height'];
+        gutterSize = gutter.getBoundingClientRect()[direction === SplitDirection.Horizontal ? 'width' : 'height'];
         gutterSize = isFirst || isLast ? gutterSize / 2 : gutterSize;
       }
 


### PR DESCRIPTION

<img width="723" alt="Screen Shot 2023-06-28 at 10 36 09 AM" src="https://github.com/devbookhq/splitter/assets/1480000/9301a684-d7ee-44ae-8829-86f0095a39c9">
<img width="1097" alt="Screen Shot 2023-06-28 at 10 36 03 AM" src="https://github.com/devbookhq/splitter/assets/1480000/fb4338ca-7ac2-4dd4-a27e-1dcd98ee8867">
Fixes #27 